### PR TITLE
Handle ghost fade zero

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -118,7 +118,10 @@ export class GameOfLife {
           }
         }
         if (newCell.ghost && newCell.ghostColor) {
-          newCell.ghostColor = this._hexToRgba(newCell.ghostColor, newCell.ghostFade || 0.13);
+          newCell.ghostColor = this._hexToRgba(
+            newCell.ghostColor,
+            newCell.ghostFade ?? 0.13
+          );
         }
         newGrid[r][c] = newCell;
       }

--- a/tests/ghostfade.test.mjs
+++ b/tests/ghostfade.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { GameOfLife } from '../src/game.js';
+
+const g = new GameOfLife(1, 1, [2], [2], 0);
+
+g.clear();
+g.paint(0, 0, '#ff0000', 'picked');
+
+g.step();
+const cell = g.getCell(0, 0);
+assert.equal(cell.ghost, 1);
+assert.equal(cell.ghostFade, 0);
+assert.ok(cell.ghostColor.endsWith(',0)'));
+
+console.log('Ghost fade 0 test passed');


### PR DESCRIPTION
## Summary
- respect explicit ghostFade zero value so ghost cells fade immediately
- test that ghost fade zero removes the cell transparency

## Testing
- `node tests/color.test.mjs && node tests/ghostfade.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68674ff9359c8330893cfe4a320fe180