### PR TITLE
Remove redundant cell size slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,6 @@
     <div id="bottom-controls">
       <div id="panel">
         <div>
-          <label for="cellsize-slider">Cell Size:</label>
-          <input type="range" id="cellsize-slider" min="5" max="40" value="13">
-          <span id="cellsize-value">13</span>
-        </div>
-        <div>
           <label for="ghostfade-slider">Ghost Fade:</label>
           <input type="range" id="ghostfade-slider" min="0" max="100" value="18">
           <span id="ghostfade-value">0.18</span>

--- a/src/main.js
+++ b/src/main.js
@@ -12,8 +12,6 @@ const zoomOutBtn = document.getElementById('zoom-out');
 const colorPicker = document.getElementById('color-picker');
 const speedSlider = document.getElementById('speed-slider');
 const speedValue = document.getElementById('speed-value');
-const cellSizeSlider = document.getElementById('cellsize-slider');
-const cellSizeValue = document.getElementById('cellsize-value');
 const ghostFadeSlider = document.getElementById('ghostfade-slider');
 const ghostFadeValue = document.getElementById('ghostfade-value');
 const colorModeSelect = document.getElementById('colormode-select');
@@ -25,7 +23,7 @@ const bsSurvive = document.getElementById('bs-survive');
 const showGridCheckbox = document.getElementById('showgrid-checkbox');
 
 // Grid settings
-let cellSize = parseInt(cellSizeSlider.value);
+let cellSize = 13;
 let rows, cols, game;
 let running = false;
 let aliveColor = colorPicker.value;
@@ -150,22 +148,13 @@ clearBtn.onclick = function() { game.clear(); drawGrid(); };
 resetBtn.onclick = function() { game.randomize(); drawGrid(); };
 zoomInBtn.onclick = function() {
   cellSize = Math.min(cellSize + 2, 40);
-  cellSizeSlider.value = cellSize;
-  cellSizeValue.innerText = cellSize;
   resizeCanvasAndGrid(true);
 };
 zoomOutBtn.onclick = function() {
   cellSize = Math.max(cellSize - 2, 5);
-  cellSizeSlider.value = cellSize;
-  cellSizeValue.innerText = cellSize;
   resizeCanvasAndGrid(true);
 };
 colorPicker.oninput = e => { aliveColor = e.target.value; };
-cellSizeSlider.oninput = function(e) {
-  cellSize = parseInt(e.target.value);
-  cellSizeValue.innerText = cellSize;
-  resizeCanvasAndGrid(true);
-};
 ghostFadeSlider.oninput = function(e) {
   ghostFadeBase = parseInt(e.target.value) / 100;
   ghostFadeValue.innerText = ghostFadeBase.toFixed(2);
@@ -221,7 +210,6 @@ canvas.addEventListener('touchend', () => painting = false);
 
 // --- Sliders display ---
 speedValue.innerText = fps;
-cellSizeValue.innerText = cellSize;
 ghostFadeValue.innerText = ghostFadeBase.toFixed(2);
 vibranceValue.innerText = vibrance;
 showGridCheckbox.checked = showGrid;

--- a/style.css
+++ b/style.css
@@ -126,7 +126,6 @@ body {
 input[type="range"] {
   width: 90px;
 }
-#cellsize-slider { width: 70px; }
 #ghostfade-slider { width: 70px; }
 #vibrance-slider { width: 70px; }
 select {
@@ -140,7 +139,7 @@ label {
   font-size: 1em;
   color: #222;
 }
-#born-value, #survive-value, #speed-value, #cellsize-value, #ghostfade-value, #vibrance-value {
+#born-value, #survive-value, #speed-value, #ghostfade-value, #vibrance-value {
   font-weight: bold;
   margin-left: 0.3em;
   color: #aa0099;


### PR DESCRIPTION
## Summary
- clean up UI by removing the cell size slider control
- simplify logic in `main.js` to rely on zoom buttons only
- drop related styles

## Testing
- `node tests/color.test.mjs`
- `node tests/ghostfade.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_686750d38c988330a624d9e6718d919f