### PR TITLE
Adjust defaults for ghost fade and grid color

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
       <div id="panel">
         <div>
           <label for="ghostfade-slider">Ghost Fade:</label>
-          <input type="range" id="ghostfade-slider" min="0" max="100" value="18">
-          <span id="ghostfade-value">0.18</span>
+          <input type="range" id="ghostfade-slider" min="0" max="100" value="0">
+          <span id="ghostfade-value">0.00</span>
         </div>
         <div>
           <label for="colormode-select">Color Mode:</label>

--- a/src/game.js
+++ b/src/game.js
@@ -2,7 +2,7 @@ export class GameOfLife {
   constructor(
     rows, cols,
     bornAt = [2], surviveCount = [2],
-    ghostFade = 0.18,
+    ghostFade = 0,
     colorMode = "picked",
     neighborType = "moore",
     vibrance = 100

--- a/src/main.js
+++ b/src/main.js
@@ -101,7 +101,7 @@ function drawGrid() {
     }
   }
   if (showGrid) {
-    ctx.strokeStyle = "rgba(0,0,0,0.3)";
+    ctx.strokeStyle = "rgba(200,200,200,0.4)";
     ctx.lineWidth = 1;
     ctx.beginPath();
     for (let x = 0; x <= cols; x++) {


### PR DESCRIPTION
## Summary
- set initial ghost fade slider to 0 in UI
- lighten grid line color
- default ghost fade parameter to 0

## Testing
- `node tests/color.test.mjs && node tests/ghostfade.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_6867527f9acc8330bb16fdd7b32b2a7d