### PR TITLE
Add time direction toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Click/drag on the canvas to paint live cells with the selected color.
 
 Click ▶ Start / ⏸ Pause to begin or stop the simulation.
 
+Click ⇆ Forward to toggle between forward and reverse playback.
+
 Adjust zoom, color, and speed as needed.
 
 Cells evolve automatically with color blending and ghosting logic.

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
         <button id="open-patterns-menu" class="pattern-menu-btn">Choose Pattern</button>
       </div>
       <button id="start-pause">&#x25B6; Start / &#x23F8; Pause</button>
+      <button id="toggle-direction">&#8646; Forward</button>
       <button id="clear">&#129689; Clear</button>
       <button id="reset">&#128260; Reset</button>
       <button id="zoom-in">&#10133;</button>

--- a/src/game.js
+++ b/src/game.js
@@ -15,6 +15,8 @@ export class GameOfLife {
     this.colorMode = colorMode;
     this.neighborType = neighborType;
     this.vibrance = vibrance;
+    this.history = [];
+    this.maxHistory = 200;
     this.hue = Math.random() * 360;
     this.randomize();
   }
@@ -36,6 +38,7 @@ export class GameOfLife {
           : { alive: 0, color: null, ghost: 0, ghostColor: null, ghostFade: 0 }
       )
     );
+    this.history = [];
   }
 
   clear() {
@@ -44,6 +47,7 @@ export class GameOfLife {
         ({ alive: 0, color: null, ghost: 0, ghostColor: null, ghostFade: 0 })
       )
     );
+    this.history = [];
   }
 
   getCell(row, col) {
@@ -62,6 +66,9 @@ export class GameOfLife {
   }
 
   step() {
+    const snapshot = this.grid.map(row => row.map(cell => ({ ...cell }))); 
+    this.history.push(snapshot);
+    if (this.history.length > this.maxHistory) this.history.shift();
     const newGrid = Array.from({ length: this.rows }, () => Array(this.cols));
     for (let r = 0; r < this.rows; r++) {
       for (let c = 0; c < this.cols; c++) {
@@ -127,6 +134,11 @@ export class GameOfLife {
       }
     }
     this.grid = newGrid;
+  }
+
+  stepBackward() {
+    if (this.history.length === 0) return;
+    this.grid = this.history.pop();
   }
 
   _neighbors(row, col) {
@@ -221,5 +233,6 @@ export class GameOfLife {
     this.rows = newRows;
     this.cols = newCols;
     this.grid = newGrid;
+    this.history = [];
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import { patternsList, insertPattern } from './patterns.js';
 const canvas = document.getElementById('game-canvas');
 const ctx = canvas.getContext('2d');
 const startPauseBtn = document.getElementById('start-pause');
+const directionToggleBtn = document.getElementById('toggle-direction');
 const clearBtn = document.getElementById('clear');
 const resetBtn = document.getElementById('reset');
 const zoomInBtn = document.getElementById('zoom-in');
@@ -42,6 +43,7 @@ let animationId = null;
 let lastFrame = 0;
 let frameInterval = 1000 / fps;
 let frameCount = 0;
+let forward = true;
 
 // --- B/S Rule Checkboxes ---
 function makeCheckboxGroup(container, arr, labelPrefix, onChange) {
@@ -126,9 +128,14 @@ function animate(now = 0) {
   if (!lastFrame) lastFrame = now;
   const elapsed = now - lastFrame;
   if (elapsed >= frameInterval) {
-    game.step();
+    if (forward) {
+      game.step();
+      frameCount++;
+    } else {
+      game.stepBackward();
+      frameCount = Math.max(0, frameCount - 1);
+    }
     drawGrid();
-    frameCount++;
     frameValue.innerText = frameCount;
     lastFrame = now;
   }
@@ -147,6 +154,10 @@ startPauseBtn.onclick = function() {
     cancelAnimationFrame(animationId);
     animationId = null;
   }
+};
+directionToggleBtn.onclick = function() {
+  forward = !forward;
+  directionToggleBtn.innerText = forward ? '\u21c6 Forward' : '\u21c6 Reverse';
 };
 clearBtn.onclick = function() {
   game.clear();

--- a/tests/backward.test.mjs
+++ b/tests/backward.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { GameOfLife } from '../src/game.js';
+
+const g = new GameOfLife(2,2,[3],[2,3]);
+g.clear();
+g.paint(0,0,'#ff0000','picked');
+const before = g.grid.map(r => r.map(c => ({...c})));
+
+g.step();
+assert.notDeepEqual(g.grid, before);
+
+g.stepBackward();
+assert.deepEqual(g.grid, before);
+
+console.log('Backward step test passed');


### PR DESCRIPTION
## Summary
- allow reversing simulation by storing grid history
- add stepBackward and history handling to GameOfLife
- new toggle-direction button and logic in main.js
- document forward/reverse control
- test backward stepping

## Testing
- `node tests/color.test.mjs`
- `node tests/ghostfade.test.mjs`
- `node tests/backward.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_686757e2746c8330b36532267eef68e9