### PR TITLE
Add color-aware pattern support

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -249,6 +249,8 @@ window.addEventListener('resize', () => resizeCanvasAndGrid(true));
 
 // --- Initial load ---
 resizeCanvasAndGrid();
+game.clear();
+insertPattern(game, Math.floor(rows/2), Math.floor(cols/2), 'Rose', aliveColor, colorMode);
 drawGrid();
 
 // --- Pattern Modal Menu ---

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -155,6 +155,17 @@ export const patternsList = {
     [1,1,0],
     [0,1,0]
   ],
+  // Example color pattern - a simple rose
+  "Rose": [
+    [0,0,"#ff0000",0,0],
+    [0,"#ff0000","#ff0000","#ff0000",0],
+    ["#ff0000","#ff0000","#ff0000","#ff0000","#ff0000"],
+    [0,"#ff0000","#ff0000","#ff0000",0],
+    [0,0,"#ff0000",0,0],
+    [0,0,"#00aa00",0,0],
+    [0,"#00aa00","#00aa00","#00aa00",0],
+    ["#00aa00",0,"#00aa00",0,"#00aa00"]
+  ],
   // Guns
   "Gosper Glider Gun": [
     [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
@@ -176,8 +187,10 @@ export function insertPattern(game, baseRow, baseCol, patternName, color, colorM
   const pc = Math.floor(pattern[0].length / 2);
   for (let r = 0; r < pattern.length; r++) {
     for (let c = 0; c < pattern[r].length; c++) {
-      if (pattern[r][c]) {
-        game.paint(baseRow + r - pr, baseCol + c - pc, color, colorMode);
+      const cell = pattern[r][c];
+      if (cell) {
+        const cellColor = typeof cell === 'string' ? cell : color;
+        game.paint(baseRow + r - pr, baseCol + c - pc, cellColor, colorMode);
       }
     }
   }

--- a/tests/colorpattern.test.mjs
+++ b/tests/colorpattern.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { GameOfLife } from '../src/game.js';
+import { insertPattern, patternsList } from '../src/patterns.js';
+
+patternsList['ColorTest'] = [
+  [0,'#ff0000'],
+  ['#00ff00',1]
+];
+
+const g = new GameOfLife(4,4);
+g.clear();
+insertPattern(g, 1, 1, 'ColorTest', '#ffffff', 'picked');
+
+assert.equal(g.getCell(0,1).color, '#ff0000');
+assert.equal(g.getCell(1,0).color, '#00ff00');
+assert.equal(g.getCell(1,1).color, '#ffffff');
+
+console.log('Color pattern insert test passed');
+


### PR DESCRIPTION
## Summary
- allow pattern cells to specify a hex color string
- add a multi-color "Rose" example pattern
- place the rose pattern on startup
- test new color pattern insertion

## Testing
- `node tests/color.test.mjs`
- `node tests/backward.test.mjs`
- `node tests/ghostfade.test.mjs`
- `node tests/colorpattern.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68675c9a87948330b0d3aa584acf1616