### PR TITLE
Default grid visible with B3/S23

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         </div>
         <div>
           <label for="showgrid-checkbox">Grid:</label>
-          <input type="checkbox" id="showgrid-checkbox">
+          <input type="checkbox" id="showgrid-checkbox" checked>
         </div>
       </div>
       <div id="patterns-panel">

--- a/src/game.js
+++ b/src/game.js
@@ -1,7 +1,7 @@
 export class GameOfLife {
   constructor(
     rows, cols,
-    bornAt = [2], surviveCount = [2],
+    bornAt = [3], surviveCount = [2, 3],
     ghostFade = 0,
     colorMode = "picked",
     neighborType = "moore",

--- a/src/main.js
+++ b/src/main.js
@@ -32,8 +32,8 @@ let running = false;
 let aliveColor = colorPicker.value;
 
 // Simulation settings (defaults)
-let bornAt = [2];
-let surviveCount = [2];
+let bornAt = [3];
+let surviveCount = [2, 3];
 let fps = parseInt(speedSlider.value);
 let ghostFadeBase = parseInt(ghostFadeSlider.value) / 100;
 let colorMode = colorModeSelect.value;


### PR DESCRIPTION
## Summary
- show gridlines by default
- use classic B3/S23 rules on startup

## Testing
- `node tests/color.test.mjs`
- `node tests/colorpattern.test.mjs`
- `node tests/ghostfade.test.mjs`
- `node tests/backward.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68675f829ff08330a5a95127c417799d