### PR TITLE
Add randomize button and limited 100x100 colorful initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
         <span id="direction-value">Forward</span>
       </div>
       <button id="clear">&#129689; Clear</button>
-      <button id="reset">&#128260; Reset</button>
+      <button id="randomize">&#127922; Randomize</button>
       <button id="zoom-in">&#10133;</button>
       <button id="zoom-out">&#10134;</button>
       <label for="color-picker" class="color-label">&#127912;</label>

--- a/src/game.js
+++ b/src/game.js
@@ -30,14 +30,19 @@ export class GameOfLife {
   setNeighborType(val) { this.neighborType = val; }
   setVibrance(val) { this.vibrance = val; }
 
-  randomize() {
-    this.grid = Array.from({ length: this.rows }, () =>
-      Array.from({ length: this.cols }, () =>
-        Math.random() > 0.8
-          ? { alive: 1, color: this._pickColor(), ghost: 0, ghostColor: null, ghostFade: 0 }
-          : { alive: 0, color: null, ghost: 0, ghostColor: null, ghostFade: 0 }
-      )
-    );
+  randomize(rRows = this.rows, rCols = this.cols) {
+    this.clear();
+    const startRow = Math.floor((this.rows - rRows) / 2);
+    const startCol = Math.floor((this.cols - rCols) / 2);
+    for (let r = 0; r < rRows && startRow + r < this.rows; r++) {
+      for (let c = 0; c < rCols && startCol + c < this.cols; c++) {
+        if (Math.random() > 0.5) {
+          const row = startRow + r;
+          const col = startCol + c;
+          this.grid[row][col] = { alive: 1, color: this._randomColor(), ghost: 0, ghostColor: null, ghostFade: 0 };
+        }
+      }
+    }
     this.history = [];
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ const startPauseBtn = document.getElementById('start-pause');
 const directionSlider = document.getElementById('direction-slider');
 const directionValue = document.getElementById('direction-value');
 const clearBtn = document.getElementById('clear');
-const resetBtn = document.getElementById('reset');
+const randomizeBtn = document.getElementById('randomize');
 const zoomInBtn = document.getElementById('zoom-in');
 const zoomOutBtn = document.getElementById('zoom-out');
 const colorPicker = document.getElementById('color-picker');
@@ -181,8 +181,8 @@ clearBtn.onclick = function() {
   frameSlider.max = frameCount;
   frameSlider.value = frameCount;
 };
-resetBtn.onclick = function() {
-  game.randomize();
+randomizeBtn.onclick = function() {
+  game.randomize(100, 100);
   drawGrid();
   frameCount = 0;
   frameValue.innerText = frameCount;


### PR DESCRIPTION
## Summary
- rename the reset button to **Randomize** in the UI
- randomize 100x100 colorful area when the new button is clicked
- support region-based randomization in the `GameOfLife` class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68678780bcd08330ba335833ca9b065b