### PR TITLE
Add mobile controls toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
   <canvas id="game-canvas"></canvas>
   <div id="ui-overlay">
+    <button id="menu-toggle">&#9776;</button>
     <div id="bottom-controls">
       <div id="panel">
         <div>

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import { patternsList, insertPattern } from './patterns.js';
 const canvas = document.getElementById('game-canvas');
 const ctx = canvas.getContext('2d');
 const startPauseBtn = document.getElementById('start-pause');
+const menuToggle = document.getElementById('menu-toggle');
+const bottomControls = document.getElementById('bottom-controls');
 const directionSlider = document.getElementById('direction-slider');
 const directionValue = document.getElementById('direction-value');
 const clearBtn = document.getElementById('clear');
@@ -159,6 +161,9 @@ startPauseBtn.onclick = function() {
     cancelAnimationFrame(animationId);
     animationId = null;
   }
+};
+menuToggle.onclick = function() {
+  bottomControls.classList.toggle('open');
 };
 directionSlider.oninput = function(e) {
   const newForward = parseInt(e.target.value) === 1;

--- a/style.css
+++ b/style.css
@@ -36,6 +36,21 @@ body {
   justify-content: flex-end;
   align-items: center;
 }
+#menu-toggle {
+  display: none;
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  z-index: 25;
+  background: #111;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 1.5em;
+  padding: 6px 12px;
+  cursor: pointer;
+  pointer-events: auto;
+}
 #bottom-controls {
   width: 100vw;
   background: rgba(255,255,255,0.95);
@@ -51,6 +66,7 @@ body {
   z-index: 20;
   position: relative;
   bottom: 0;
+  transition: transform 0.3s ease;
 }
 #panel {
   display: flex;
@@ -156,10 +172,19 @@ label {
   #patterns-panel { margin-right: 0.7em; }
 }
 @media (max-width: 900px) {
+  #menu-toggle { display: block; }
   #bottom-controls {
     flex-direction: column;
     gap: 0.7em;
     padding: 8px 2vw 10px 2vw;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    transform: translateY(100%);
+    width: 100vw;
+  }
+  #bottom-controls.open {
+    transform: none;
   }
   #panel { flex-direction: column; gap: 0.4em; margin-right: 0; }
   #patterns-panel { margin-right: 0; }


### PR DESCRIPTION
## Summary
- add a hamburger `menu-toggle` button for mobile
- animate `bottom-controls` with an `.open` class
- show/hide the mobile controls with JS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68678850054083308b4daf3753f2a7ff