### PR TITLE
Fix randomize bounds and add size test

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -32,8 +32,12 @@ export class GameOfLife {
 
   randomize(rRows = this.rows, rCols = this.cols) {
     this.clear();
-    const startRow = Math.floor((this.rows - rRows) / 2);
-    const startCol = Math.floor((this.cols - rCols) / 2);
+    rRows = Math.min(rRows, this.rows);
+    rCols = Math.min(rCols, this.cols);
+    let startRow = Math.floor((this.rows - rRows) / 2);
+    let startCol = Math.floor((this.cols - rCols) / 2);
+    startRow = Math.max(0, startRow);
+    startCol = Math.max(0, startCol);
     for (let r = 0; r < rRows && startRow + r < this.rows; r++) {
       for (let c = 0; c < rCols && startCol + c < this.cols; c++) {
         if (Math.random() > 0.5) {

--- a/tests/randomize-size.test.mjs
+++ b/tests/randomize-size.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { GameOfLife } from '../src/game.js';
+
+const g = new GameOfLife(3, 3);
+assert.doesNotThrow(() => g.randomize(100, 100));
+
+for (let r = 0; r < g.rows; r++) {
+  for (let c = 0; c < g.cols; c++) {
+    const cell = g.getCell(r, c);
+    assert.ok(cell && typeof cell.alive === 'number');
+  }
+}
+
+console.log('Randomize size test passed');


### PR DESCRIPTION
## Summary
- ensure `randomize()` respects board size and handles large sizes
- add regression test to verify oversize randomization works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68678a089eb0833098e9fa049358869d