### PR TITLE
Improve randomize palette

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -38,16 +38,30 @@ export class GameOfLife {
     let startCol = Math.floor((this.cols - rCols) / 2);
     startRow = Math.max(0, startRow);
     startCol = Math.max(0, startCol);
+
+    const palette = this._generatePalette(5);
+
     for (let r = 0; r < rRows && startRow + r < this.rows; r++) {
       for (let c = 0; c < rCols && startCol + c < this.cols; c++) {
         if (Math.random() > 0.5) {
           const row = startRow + r;
           const col = startCol + c;
-          this.grid[row][col] = { alive: 1, color: this._randomColor(), ghost: 0, ghostColor: null, ghostFade: 0 };
+          const color = palette[Math.floor(Math.random() * palette.length)];
+          this.grid[row][col] = { alive: 1, color, ghost: 0, ghostColor: null, ghostFade: 0 };
         }
       }
     }
     this.history = [];
+  }
+
+  _generatePalette(count = 5) {
+    const baseHue = Math.floor(Math.random() * 360);
+    const palette = [];
+    for (let i = 0; i < count; i++) {
+      const hue = (baseHue + i * 15 + Math.random() * 10) % 360;
+      palette.push(`hsl(${hue},${this.vibrance}%,60%)`);
+    }
+    return palette;
   }
 
   clear() {

--- a/src/main.js
+++ b/src/main.js
@@ -187,7 +187,7 @@ clearBtn.onclick = function() {
   frameSlider.value = frameCount;
 };
 randomizeBtn.onclick = function() {
-  game.randomize(100, 100);
+  game.randomize(50, 50);
   drawGrid();
   frameCount = 0;
   frameValue.innerText = frameCount;

--- a/tests/randomize-colorpalette.test.mjs
+++ b/tests/randomize-colorpalette.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { GameOfLife } from '../src/game.js';
+
+const g = new GameOfLife(10, 10);
+const aliveColors = new Set();
+for (let i=0;i<3;i++) {
+  g.randomize(10,10);
+  aliveColors.clear();
+  for (let r=0;r<g.rows;r++) {
+    for (let c=0;c<g.cols;c++) {
+      const cell = g.getCell(r,c);
+      if (cell.alive) aliveColors.add(cell.color);
+    }
+  }
+  assert.ok(aliveColors.size <= 5, `too many colors: ${aliveColors.size}`);
+}
+console.log('Randomize palette test passed');


### PR DESCRIPTION
## Summary
- create _generatePalette for matching color schemes
- use the palette in randomize and limit to 5 colors
- randomize only a 50x50 region from the UI
- test palette size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68678dcffd1883308406a35acc59fbcf