### PR TITLE
Fix mobile menu toggle on touch devices

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -162,9 +162,14 @@ startPauseBtn.onclick = function() {
     animationId = null;
   }
 };
-menuToggle.onclick = function() {
+function toggleMenu() {
   bottomControls.classList.toggle('open');
-};
+}
+menuToggle.addEventListener('click', toggleMenu);
+menuToggle.addEventListener('touchstart', function(e) {
+  e.preventDefault();
+  toggleMenu();
+});
 directionSlider.oninput = function(e) {
   const newForward = parseInt(e.target.value) === 1;
   if (newForward !== forward) {


### PR DESCRIPTION
## Summary
- improve mobile menu toggle by adding a reusable function
- attach both click and touchstart handlers so the menu works on touch screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68679311502883309bf3b5023d164db5