### PR TITLE
Add accessibility attributes for menu toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <canvas id="game-canvas"></canvas>
   <div id="ui-overlay">
-    <button id="menu-toggle">&#9776;</button>
+    <button id="menu-toggle" aria-expanded="false" aria-label="Toggle controls">&#9776;</button>
     <div id="bottom-controls">
       <div id="panel">
         <div>

--- a/src/main.js
+++ b/src/main.js
@@ -163,7 +163,8 @@ startPauseBtn.onclick = function() {
   }
 };
 function toggleMenu() {
-  bottomControls.classList.toggle('open');
+  const open = bottomControls.classList.toggle('open');
+  menuToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
 }
 menuToggle.addEventListener('click', toggleMenu);
 menuToggle.addEventListener('touchstart', function(e) {


### PR DESCRIPTION
## Summary
- add `aria-expanded="false"` and `aria-label` to the menu button
- update `toggleMenu` to keep `aria-expanded` in sync with menu state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68683c1349c08330bd17ce8436fdd13c